### PR TITLE
Add accelerometer crate support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: [ [ ], [ "--all-features" ] ]
+        features: [ [ ], [ "--all-features" ], [ "--no-default-features" ] ]
     steps:
       - uses: actions/checkout@v4
       - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/japaric/lsm303dlhc"
 version = "0.2.0"
 
 [dependencies]
+accelerometer = "0.5"
 embedded-hal = "0.2.0"
 generic-array = "0.11.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,16 @@ name = "lsm303dlhc"
 repository = "https://github.com/sunsided/lsm303dlhc"
 version = "0.2.0"
 
+[features]
+default = ["accelerometer"]
+accelerometer = ["dep:accelerometer"]
+
 [dependencies]
-accelerometer = "0.5"
+accelerometer = { version = "0.12.0", optional = true }
 cast = { version = "0.3.0", default-features = false }
 embedded-hal = "0.2.7"
 generic-array = "1.0.0"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/accelerometer_impl.rs
+++ b/src/accelerometer_impl.rs
@@ -1,0 +1,104 @@
+//! Provides support for the `accelerometer` crate.
+
+use accel;
+use accelerometer::vector::F32x3;
+use accelerometer::{Accelerometer, Error, RawAccelerometer};
+use core::fmt::Debug;
+use hal::blocking::i2c::{Write, WriteRead};
+use {I16x3, LSM303DLHC};
+
+impl<I2C, E> RawAccelerometer<accelerometer::vector::I16x3> for LSM303DLHC<I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    E: Debug,
+{
+    type Error = E;
+
+    fn accel_raw(&mut self) -> Result<accelerometer::vector::I16x3, Error<Self::Error>> {
+        self.accel().map(Into::into).map_err(Into::into)
+    }
+}
+
+impl<I2C, E> Accelerometer for LSM303DLHC<I2C>
+where
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    E: Debug,
+{
+    type Error = E;
+
+    fn accel_norm(&mut self) -> Result<F32x3, Error<Self::Error>> {
+        let reading = self.accel_raw()?;
+
+        // Original source: https://github.com/rubberduck203/stm32f3-discovery/blob/45c7f1b4375d6c4b7ab4f70d5699323d6feb98cc/src/compass.rs
+        // SPDX-License-Identifier: MIT or Apache-2.0
+        //
+        // LA_FS (linear acceleration measurement range [full scale])
+        //  can be +/-2, +/-4, +/-8, or +/- 16
+        // LA_So (Linear acceleration sensitivity) can be 1,2,4, or 12
+        //  and is measured in milli-G / LSB
+        // The driver provides a way to set the range/sensitivity,
+        // but no way to read it, so we just hard code the default settings here (for now?).
+        //
+        // At +/-2g, we get 1mg/LSB (1 mg/bit) resolution.
+        // The device returns a 16 bit result.
+        // magnitude g / (1 mg / bit) =
+        // +/- 2g range = 4g magnitude
+        // 4g / 65535 bits = 4g/(1<<16) = 0.000061 g / bit
+        // 2g / 32768 bits = 2g/(1<<15) = 0.000061 g / bit
+        //
+        // I _think_ the general equation is:
+        // scale_factor = magnitude / #of_bits * sensitivity
+        // scale_factor = (abs(range)*2) / #of_bits * sensitivity
+        // scale_factor = abs(range) / (#of_bits/2) * sensitivity
+        // sf(+/-2g)  =  4g / 65535 bits *  1mg/LSB = 0.000061 g
+        // sf(+/-4g)  =  8g / 65535 bits *  2mg/LSB = 0.000244 g
+        // sf(+/-8g)  = 16g / 65535 bits *  4mg/LSB = 0.000976 g
+        // sf(+/-16g) = 32g / 65535 bits * 12mg/LSB = 0.005859 g
+
+        // NOTE: This also does not account for temperature variance.
+        const MAGNITUDE: i32 = 4;
+        const NO_OF_BITS: i32 = 1 << 16;
+        const SENSITIVITY: i32 = 1;
+        const SCALE_FACTOR: f32 = (MAGNITUDE as f32 / NO_OF_BITS as f32) * SENSITIVITY as f32;
+        Ok(F32x3::new(
+            reading.x as f32 * SCALE_FACTOR,
+            reading.y as f32 * SCALE_FACTOR,
+            reading.z as f32 * SCALE_FACTOR,
+        ))
+    }
+
+    fn sample_rate(&mut self) -> Result<f32, Error<Self::Error>> {
+        let register = self.read_accel_register(accel::Register::CTRL_REG1_A)?;
+        let odr = ((register & 0b1111_0000) >> 4) & 0b0000_1111;
+        let lpen = (register & 0b0000_1000) >> 3;
+        match odr {
+            0b0000 => Ok(0.0),    // Power-down mode
+            0b0001 => Ok(1.0),    // 1 Hz
+            0b0010 => Ok(10.0),   // 10 Hz
+            0b0011 => Ok(25.0),   // 25 Hz
+            0b0100 => Ok(50.0),   // 50 Hz
+            0b0101 => Ok(100.0),  // 100 Hz
+            0b0110 => Ok(200.0),  // 200 Hz
+            0b0111 => Ok(400.0),  // 400 Hz
+            0b1000 => Ok(1620.0), // 1.620 kHz (low-power mode)
+            0b1001 => {
+                if lpen == 0 {
+                    Ok(1344.0) // 1.344 kHz in normal mode
+                } else {
+                    Ok(5376.0) // 5.376 kHz in low-power mode
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<I16x3> for accelerometer::vector::I16x3 {
+    fn from(value: I16x3) -> Self {
+        accelerometer::vector::I16x3 {
+            x: value.x,
+            y: value.y,
+            z: value.z,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 // Enables the `doc_cfg` feature when the `docsrs` configuration attribute is defined.
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "accelerometer")]
 extern crate accelerometer;
 extern crate cast;
 extern crate embedded_hal as hal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![no_std]
+// Enables the `doc_cfg` feature when the `docsrs` configuration attribute is defined.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate accelerometer;
 extern crate cast;
@@ -20,15 +22,17 @@ extern crate embedded_hal as hal;
 extern crate generic_array;
 
 use core::fmt::Debug;
-use core::mem;
 
-pub use accelerometer::{Accelerometer, I16x3};
 use cast::u16;
 use generic_array::typenum::consts::*;
 use generic_array::{ArrayLength, GenericArray};
 use hal::blocking::i2c::{Write, WriteRead};
 
 mod accel;
+
+#[cfg(feature = "accelerometer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "accelerometer")))]
+mod accelerometer_impl;
 mod mag;
 pub mod wrapper;
 
@@ -66,6 +70,17 @@ where
         lsm303dlhc.write_mag_register(mag::Register::CRA_REG_M, 0b0001000 | (1 << 7))?;
 
         Ok(lsm303dlhc)
+    }
+
+    /// Accelerometer measurements
+    pub fn accel(&mut self) -> Result<I16x3, E> {
+        let buffer: GenericArray<u8, U6> = self.read_accel_registers(accel::Register::OUT_X_L_A)?;
+
+        Ok(I16x3 {
+            x: (u16(buffer[0]) + (u16(buffer[1]) << 8)) as i16,
+            y: (u16(buffer[2]) + (u16(buffer[3]) << 8)) as i16,
+            z: (u16(buffer[4]) + (u16(buffer[5]) << 8)) as i16,
+        })
     }
 
     /// Sets the accelerometer output data rate
@@ -190,23 +205,15 @@ where
     }
 }
 
-impl<I2C, E> Accelerometer<I16x3> for Lsm303dlhc<I2C>
-where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
-    E: Debug,
-{
-    type Error = E;
-
-    /// Accelerometer measurements
-    fn acceleration(&mut self) -> Result<I16x3, E> {
-        let buffer: GenericArray<u8, U6> = self.read_accel_registers(accel::Register::OUT_X_L_A)?;
-
-        Ok(I16x3 {
-            x: (u16(buffer[0]) + (u16(buffer[1]) << 8)) as i16,
-            y: (u16(buffer[2]) + (u16(buffer[3]) << 8)) as i16,
-            z: (u16(buffer[4]) + (u16(buffer[5]) << 8)) as i16,
-        })
-    }
+/// XYZ triple
+#[derive(Debug)]
+pub struct I16x3 {
+    /// X component
+    pub x: i16,
+    /// Y component
+    pub y: i16,
+    /// Z component
+    pub z: i16,
 }
 
 /// Accelerometer Output Data Rate


### PR DESCRIPTION
Brings in https://github.com/tarcieri/lsm303dlhc/commit/30b4b31bc39af617f3f66ee8b03dd192e98ce716 as well as the compass logic from [rubberduck203/stm32f3-discovery/src/compass.rs](https://github.com/rubberduck203/stm32f3-discovery/blob/45c7f1b4375d6c4b7ab4f70d5699323d6feb98cc/src/compass.rs).