### PR TITLE
Add fixed-point temperature conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/sunsided/lsm303dlhc"
 default = ["accelerometer"]
 accelerometer = ["dep:accelerometer"]
 defmt = ["dep:defmt", "lsm303dlhc-registers/defmt"]
+fixed = ["dep:fixed"]
 
 [dependencies]
 accelerometer = { version = "0.12.0", optional = true }
@@ -20,6 +21,7 @@ bitfield-struct = "0.8.0"
 cast = { version = "0.3.0", default-features = false }
 defmt = { version = "0.3.8", optional = true }
 embedded-hal = "0.2.7"
+fixed = { version = "1.27.0", optional = true }
 generic-array = "1.0.0"
 lsm303dlhc-registers = "0.1.0"
 

--- a/src/accelerometer_impl.rs
+++ b/src/accelerometer_impl.rs
@@ -15,7 +15,7 @@ where
     type Error = E;
 
     fn accel_raw(&mut self) -> Result<accelerometer::vector::I16x3, Error<Self::Error>> {
-        self.accel().map(Into::into).map_err(Into::into)
+        self.accel_raw().map(Into::into).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
Uses the `fixed` crate as an optional dependency to provide readings in fixed-point format.